### PR TITLE
Ph dev

### DIFF
--- a/plotting/plot_contour_maps.py
+++ b/plotting/plot_contour_maps.py
@@ -1,0 +1,260 @@
+from collections import defaultdict
+import datetime
+
+from matplotlib.colors import Normalize
+#  This runs into an issue under Mac OS X, thus the workaround.
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    import matplotlib
+    matplotlib.use('PS')
+    from matplotlib import pyplot as plt
+
+import numpy as np
+import pymongo
+import scipy as sp
+from scipy.interpolate import griddata
+
+import util.util_db_access as uda
+
+
+""" 
+
+-*- coding: utf-8 -*-
+
+Legal:
+    (C) Copyright IBM 2018.
+
+    This code is licensed under the Apache License, Version 2.0. You may
+    obtain a copy of this license in the LICENSE.txt file in the root 
+    directory of this source tree or at 
+    http://www.apache.org/licenses/LICENSE-2.0.
+
+    Any modifications or derivative works of this code must retain this
+    copyright notice, and modified files need to carry a notice 
+    indicating that they have been altered from the originals.
+
+    IBM-Review-Requirement: Art30.3
+    Please note that the following code was developed for the project 
+    VaVeL at IBM Research -- Ireland, funded by the European Union under 
+    the Horizon 2020 Program.
+    The project started on December 1st, 2015 and was completed by 
+    December 1st, 2018. Thus, in accordance with Article 30.3 of the 
+    Multi-Beneficiary General Model Grant Agreement of the Program, 
+    there are certain limitations in force  up to December 1st, 2022. 
+    For further details please contact Jakub Marecek 
+    (jakub.marecek@ie.ibm.com) or Gal Weiss (wgal@ie.ibm.com).
+
+If you use the code, please cite our paper:
+https://arxiv.org/abs/1810.09425
+
+Authors: 
+    Philipp Hähnel <phahnel@hsph.harvard.edu>
+
+Last updated:
+    2019 - 08 - 30
+
+"""
+
+
+def get_parameters():
+    """
+    :return:
+    """
+    #  time slice (2017-07-01 01:00:00 to 2018-05-02 14:00:00)
+    param = {
+        'case': 'Demo',
+        'date_start': datetime.datetime(2017, 10, 22, 0),
+        'date_end': datetime.datetime(2017, 10, 23, 0),
+        'iteration': 1,
+        'pollutants': ['NO2'],
+        'resolution': 150,
+    }
+    return param
+
+
+class MidpointNormalize(Normalize):
+    """ from https://matplotlib.org/users/colormapnorms.html """
+    def __init__(self, vmin, vmax, midpoint=0, clip=False):
+        self.midpoint = midpoint
+        super().__init__(vmin, vmax, clip)
+
+    def __call__(self, value, clip=None):
+        normalized_min = max(
+            0,
+            1 / 2 * (1 - abs((self.midpoint - self.vmin)
+                             / (self.midpoint - self.vmax)))
+        )
+        normalized_max = min(
+            1,
+            1 / 2 * (1 + abs((self.vmax - self.midpoint)
+                             / (self.midpoint - self.vmin)))
+        )
+        normalized_mid = 0.5
+        x = [self.vmin, self.midpoint, self.vmax]
+        y = [normalized_min, normalized_mid, normalized_max]
+        return sp.ma.masked_array(sp.interp(value, x, y))
+
+
+def plot_heatmap(date, **kwargs):
+    print('Getting Caline estimates ...')
+    caline_estimates, receptor_list = uda.get_estimates(
+        collection_estimates=collection_caline_estimates,
+        date_start=date,
+        date_end=date,
+        case=kwargs['case']
+    )
+    caline_data = defaultdict(list)
+    caline_dict = defaultdict(dict)  # just for convenience
+    # turn {timestamp: {coord: {pollutant: value}}}
+    # into {pollutant: [coord.x, coord.y, value]}
+    for _, receptor_values in caline_estimates.items():
+        for coord, pollution_values in receptor_values.items():
+            for pollutant, value in pollution_values.items():
+                caline_data[pollutant].append(list(coord) + [value])
+                caline_dict[pollutant][coord] = value
+
+    print('Getting MLP estimates ...')
+    ml_filter = {
+        'iteration': kwargs['iteration']
+        # 'settings.gamma': gamma,
+        # 'settings.kappa': kappa,
+        # 'settings': iter
+    }
+    ml_estimates, receptor_list = uda.get_estimates(
+        collection_estimates=collection_estim,
+        date_start=date,
+        date_end=date,
+        **ml_filter
+    )
+    ml_data = defaultdict(list)
+    diff = defaultdict(list)
+    # turn {timestamp: {coord: {pollutant: value}}}
+    # into {pollutant: [coord.x, coord.y, value]}
+    for _, receptor_values in ml_estimates.items():
+        for coord, pollution_values in receptor_values.items():
+            for pollutant, value in pollution_values.items():
+                ml_data[pollutant].append(list(coord) + [value])
+                diff[pollutant].append(
+                    list(coord) + [caline_dict[pollutant][coord] - value]
+                )
+
+    print('Plotting heatmap ...')
+    for p, poll in enumerate(kwargs['pollutants']):
+
+        xi, yi, zi = [], [], []
+        ml_xi, ml_yi, ml_zi = [], [], []
+        d_xi, d_yi, d_zi = [], [], []
+
+        if poll in caline_data:
+            [y, x, z] = np.transpose(caline_data[poll])
+            xi = np.linspace(min(x), max(x), kwargs['resolution'])
+            yi = np.linspace(min(y), max(y), kwargs['resolution'])
+            zi = griddata((x, y), z,
+                          (xi[None, :], yi[:, None]),
+                          method='nearest')
+        if poll in ml_data:
+            [ml_y, ml_x, ml_z] = np.transpose(ml_data[poll])
+            ml_xi = np.linspace(min(ml_x), max(ml_x), kwargs['resolution'])
+            ml_yi = np.linspace(min(ml_y), max(ml_y), kwargs['resolution'])
+            ml_zi = griddata((ml_x, ml_y), ml_z,
+                             (ml_xi[None, :], ml_yi[:, None]),
+                             method='nearest')
+        if poll in diff:
+            [d_y, d_x, d_z] = np.transpose(diff[poll])
+            d_xi = np.linspace(min(d_x), max(d_x), kwargs['resolution'])
+            d_yi = np.linspace(min(d_y), max(d_y), kwargs['resolution'])
+            d_zi = griddata((d_x, d_y), d_z,
+                            (d_xi[None, :], d_yi[:, None]),
+                            method='nearest')
+
+        # Layout of the plot:
+        #
+        # Caline estimates. differences
+        # position map    . ML estimates
+
+        fig = plt.figure(figsize=(15, 10))
+        st = plt.suptitle(
+            'Pollution estimates for ' + kwargs['case'] + ' for ' + str(date)
+            + '\n'
+            + poll + ' concentration levels in [micrograms/m3]',
+            fontsize='x-large'
+        )
+
+        sub1 = fig.add_subplot(2, 2, 1)
+        sub1.set_title('Caline estimates')
+        plt.contour(xi, yi, zi, 10, linewidths=0.5, colors='k')
+        plt.contourf(xi, yi, zi, 15, cmap='YlOrRd')
+        plt.colorbar()
+        plt.xlabel('Longitude')
+        plt.ylabel('Latitude')
+
+        sub2 = fig.add_subplot(2, 2, 2)
+        sub2.set_title('Differences between Caline and ML estimates')
+        plt.contour(d_xi, d_yi, d_zi, 10, linewidths=0.5, colors='k')
+        plt.contourf(d_xi, d_yi, d_zi, 15,
+                     cmap='seismic',
+                     norm=MidpointNormalize(
+                         vmin=np.min(d_zi),
+                         vmax=np.max(d_zi),
+                         midpoint=0
+                     ))
+        plt.colorbar()
+        plt.xlabel('Longitude')
+        plt.ylabel('Latitude')
+
+        # sub3 = fig.add_subplot(2, 2, 3)
+        # plot_receptor_map()
+
+        sub4 = fig.add_subplot(2, 2, 4)
+        sub4.set_title('ML estimates after ' + str(kwargs['iteration'])
+                       + ' iteration(s)')
+        plt.contour(ml_xi, ml_yi, ml_zi, 10, linewidths=0.5, colors='k')
+        plt.contourf(ml_xi, ml_yi, ml_zi, 15, cmap='YlOrRd')
+        plt.colorbar()
+        plt.xlabel('Longitude')
+        plt.ylabel('Latitude')
+
+        # shift subplots down:
+        st.set_y(0.95)
+        fig.subplots_adjust(top=0.85, hspace=0.3)
+
+        plt.savefig(
+            img_path + 'contour_maps/' + poll + '/'
+            + kwargs['case']
+            + '_' + str(kwargs['iteration'])
+            + '_' + date.strftime('%Y-%m-%d_%H')
+            + '.pdf'
+        )
+        plt.close()
+
+    return None
+
+
+if __name__ == '__main__':
+
+    benchmark_path = '../output/benchmarks/'
+    img_path = '../output/img/'
+
+    """ connect to internal Mongo database """
+    client = pymongo.MongoClient('localhost', 27018)
+    # 2017-07-01 01:00:00 to 2018-05-02 14:00:00
+    collection_measurement = client.db_air_quality.pollution_measurements
+    collection_caline_estimates = client.db_air_quality.caline_estimates
+    collection_estim = client.db_air_quality.ml_estimates
+    collection_util = client.db_air_quality.util
+
+    parameters = get_parameters()
+
+    date_start = parameters['date_start']
+    date_end = parameters['date_end']
+    time_step = datetime.timedelta(hours=1)
+
+    current = date_start
+
+    while current <= date_end:
+        plot_heatmap(
+            date=current,
+            **parameters
+        )
+        current += time_step

--- a/plotting/plot_maps.py
+++ b/plotting/plot_maps.py
@@ -46,7 +46,7 @@ Authors:
     Philipp Hähnel <phahnel@hsph.harvard.edu>
 
 Last updated:
-    2019 - 08 - 02
+    2019 - 08 - 30
 
 """
 
@@ -68,16 +68,22 @@ def get_parameters():
         'comment': ''
     }
     # runs selectors from the caline_estimates
-    # distances = [
-    #     5, 6, 7, 8, 9, 10, 11, 13, 17, 27, 37, 53, 71, 101, 103
-    # ]  # Demo
-    distances = [
-        6, 11, 17, 20, 26, 33, 37, 47, 77, 105, 125, 160, 550, 600, 750
-    ]  # Dublin
+    case = 'Demo'  # 'Demo' or 'Dublin'
+    if case == 'Demo':
+        distances = [
+            5, 6, 7, 8, 9, 10, 11, 13, 17, 27, 37, 53, 71, 101, 103
+        ]
+    elif case == 'Dublin':
+        distances = [
+            6, 11, 17, 20, 26, 33, 37, 47, 77, 105, 125, 160, 550, 600, 750
+        ]
+    else:
+        distances = []
+
     param['tags'] = [{
             'run_tag': '2019-07-04',
             'contour_distance': dist,
-            'case': 'Dublin'  # 'Demo' or 'Dublin'
+            'case': case
         }
         for dist in distances
     ]

--- a/run/run_ml_model.py
+++ b/run/run_ml_model.py
@@ -65,14 +65,14 @@ def get_parameters():
         'tiles': [6, 7],  # list of id's to be used in modeling
         # 'tiles': list(range(1, 12 + 1)),
         # model hyper-parameters
-        'num_iterations': 10,
-        'num_hidden_layers': 3,
+        'num_iterations': 11,
+        'num_hidden_layers': 5,
         'num_nodes': 50,
-        'num_epochs': 10,
+        'num_epochs': 50,
         'batch_size': 128,
         'l2_reg_coefficient': 1e-4,  # weights are regularized with l2 norm
-        'starter_learning_rate': 1e-4,
-        'decay_factor': 0.9,  # exponential decay
+        'starter_learning_rate': 1e-3,
+        'decay_factor': 0.95,  # exponential decay
         'train_to_test_split': 0.9,  # train_% + test_% = 1
         'add_previous_labels_to_input': False,
         # ToDo: allow True in update of consistency constraint data
@@ -88,7 +88,7 @@ def get_parameters():
         'do_save_cc': True,
         'do_save_model': True,
         'do_save_estimates': True,
-        'iterations_to_save_estimates': [1, 2, 5, 8],  # 1-based
+        'iterations_to_save_estimates': [1, 2, 5, 10, 20, 30, 40, 50],  # 1-based
         'do_print_status': True,
         # for reproducibility
         'random_seed': None

--- a/run/run_ml_model.py
+++ b/run/run_ml_model.py
@@ -71,7 +71,7 @@ def get_parameters():
         'num_epochs': 10,
         'batch_size': 128,
         'l2_reg_coefficient': 1e-4,  # weights are regularized with l2 norm
-        'starter_learning_rate': 1e-2,
+        'starter_learning_rate': 1e-4,
         'decay_factor': 0.9,  # exponential decay
         'train_to_test_split': 0.9,  # train_% + test_% = 1
         'add_previous_labels_to_input': False,
@@ -88,7 +88,7 @@ def get_parameters():
         'do_save_cc': True,
         'do_save_model': True,
         'do_save_estimates': True,
-        'iterations_to_save_estimates': [0, 1, 2, 5, 8],
+        'iterations_to_save_estimates': [1, 2, 5, 8],  # 1-based
         'do_print_status': True,
         # for reproducibility
         'random_seed': None
@@ -127,9 +127,15 @@ def main():
         print(f'Labels mean: {np.mean(all_data)}')
         print(f'Labels max: {np.max(all_data)}\n')
 
-    for iteration in range(param['num_iterations']):
+    normalisation_stats = collections['data'].find({
+        'util.case': param['case']
+    })[0]['util']['utils']
+
+    # iterations are 1-based
+    for iteration in range(1, param['num_iterations'] + 1):
         mlp_times = umm.run_recursion_cycle(data, mesh, iteration,
-                                            collections['pred'], **param)
+                                            collections['pred'],
+                                            normalisation_stats, **param)
         if param['use_consistency_constraints']:
             ucc.update_consistency_constraints(data, mesh, iteration, **param)
         if param['do_print_status']:

--- a/run/run_pre_processing.py
+++ b/run/run_pre_processing.py
@@ -420,7 +420,7 @@ def main():
                                                   traffic_links_sorted)
 
         print('Getting Caline data ...')
-        caline_estimates, receptor_list = uda.get_caline_estimates(
+        caline_estimates, receptor_list = uda.get_estimates(
             collection_caline_estimates,
             param['date start'], param['date end'],
             **tag_dict

--- a/util/util_ml_model.py
+++ b/util/util_ml_model.py
@@ -179,7 +179,8 @@ def multilayer_perceptron(input_data, weights, biases, num_hidden_layers=4):
         hidden = tf.nn.relu(hidden)
 
     hidden = dense(hidden, weights['out'], biases['out'])
-    out_layer = tf.nn.relu(hidden)
+    # out_layer = tf.nn.relu(hidden)
+    out_layer = hidden
     return out_layer
 
 

--- a/util/util_save_benchmarks.py
+++ b/util/util_save_benchmarks.py
@@ -41,7 +41,7 @@ Authors:
     Philipp Hähnel <phahnel@hsph.harvard.edu>
 
 Last updated:
-    2019 - 08 - 14
+    2019 - 08 - 30
 
 """
 
@@ -166,7 +166,7 @@ def save_benchmarks(tile, iteration, num_instances, num_input, num_classes,
     return None
 
 
-def save_ml_estimates(estimates, inputs, iteration, tile, collection_mlp_estim,
+def save_ml_estimates(estimates, inputs, iteration, collection_mlp_estim,
                       normalisation_stats, **kwargs):
 
     def inv_normalise(value, mean, std):
@@ -214,23 +214,6 @@ def save_ml_estimates(estimates, inputs, iteration, tile, collection_mlp_estim,
                         'seed': kwargs['random_seed']
                     }
                 })
-                # save.append({
-                #     'tile': tile,
-                #     'input': list(xinput),
-                #     'labels': list(estimates[i]),
-                #     'settings': {
-                #         'gamma': kwargs['cc_reg_coefficient'],
-                #         'kappa': kwargs['kappa'],
-                #         'iteration': iteration,
-                #         'layers': kwargs['num_hidden_layers'],
-                #         'neurons': kwargs['num_nodes'],
-                #         'epochs': kwargs['num_epochs'],
-                #         'batch size': kwargs['batch_size'],
-                #         'learning rate': kwargs['starter_learning_rate'],
-                #         'comment': kwargs['cc_update_version'],
-                #         'seed': kwargs['random_seed']
-                #     }
-                # })
                 # collect estimates in a batch and then write batch to database
                 if len(save) < 100000:
                     continue


### PR DESCRIPTION
The biggest change is that the pre-processing step does no longer prepare the data in exactly the same way as it was handed to Caline, but splits the labels by each individual receptor. Further, the ML model estimates are stored in the database in essentially the same format as the Caline estimates, making their retrieval much simpler. This however now leads to a substantial memory burden when retrieving the samples from the database. For future use, it may be best to move the collection step into the loop over each subdomains, and only retrieve the data for the specific subdomain. This takes a toll on the overall runtime though.

Other improvements are concerning the plotting of the data, most notably the script for plotting time series data and the contour maps.

Removing the ReLu activation from the last layer was crucial to get any kind of sensible output.